### PR TITLE
Fix a typo in includes that failed the compilation

### DIFF
--- a/EmpiricalPseudopotential/EPseudopotentialFrame.h
+++ b/EmpiricalPseudopotential/EPseudopotentialFrame.h
@@ -34,7 +34,7 @@
 
 #include "vtkTable.h"
 #include "vtkArray.h"
-#include "VtkFloatArray.h"
+#include "vtkFloatArray.h"
 #include "vtkNew.h"
 #include "vtkChart.h"
 #include "vtkChartXY.h"


### PR DESCRIPTION
At line 37, their is an uppercase V in #include "VtkFloatArray.h", while it should be only lower case, 
as for all the others vtk includes.